### PR TITLE
package info should return None

### DIFF
--- a/uiautomator2/adbutils.py
+++ b/uiautomator2/adbutils.py
@@ -126,4 +126,6 @@ class Adb(object):
         version_name = m.group('name') if m else None
         m = re.search(r'PackageSignatures\{(.*?)\}', output)
         signature = m.group(1) if m else None
+        if version_name is None and signature is None:
+            return None
         return dict(version_name=version_name, signature=signature)


### PR DESCRIPTION
I found some bug.

https://github.com/openatx/uiautomator2/blob/master/uiautomator2/__main__.py#L139
Actually, according to previous package_info method, `pkg_info` is always a dict even both version_name and signature are None. So here `if pkg_info or test_pkg_info:` always return `True`.

And in some phone(As for me, it's Galaxy Note 8), the first time to install uiautomator apk, the main script will try to uninstall `com.github.uiautomator` and `com.github.uiautomator.test`, which will raise Exceptions. See the picture below. So I prefer to modifing the package_info method or can change the invoking places.

![image](https://user-images.githubusercontent.com/2221926/40350407-4889ff32-5ddc-11e8-94e5-d3cf7dcf8c60.png)



