### PR TITLE
增加init对重启atx-agent daemon的支持

### DIFF
--- a/uiautomator2/__main__.py
+++ b/uiautomator2/__main__.py
@@ -347,6 +347,25 @@ class MyFire(object):
         u.app_install(app_url)
         u.app_install(app_test_url)
 
+    def restart(self, serial=None):
+        """ re launch atx-agent daemon """
+        if not serial:
+            output = subprocess.check_output(['adb', 'devices'])
+            pattern = re.compile(
+                r'(?P<serial>[^\s]+)\t(?P<status>device|offline)')
+            matches = pattern.findall(output.decode())
+            valid_serials = [m[0] for m in matches if m[1] == 'device']
+            if len(valid_serials) == 0:
+                log.warning("No avaliable android devices detected.")
+                return
+            log.info("Detect pluged devices: %s", valid_serials)
+            for serial in valid_serials:
+                self._restart_with_serial(serial)
+
+    def _restart_with_serial(self, serial):
+        ins = Installer(serial)
+        ins.launch_and_check()
+
 
 def main():
     fire.Fire(MyFire)

--- a/uiautomator2/__main__.py
+++ b/uiautomator2/__main__.py
@@ -361,10 +361,15 @@ class MyFire(object):
             log.info("Detect pluged devices: %s", valid_serials)
             for serial in valid_serials:
                 self._restart_with_serial(serial)
+        else:
+            self._restart_with_serial(serial)
 
     def _restart_with_serial(self, serial):
-        ins = Installer(serial)
-        ins.launch_and_check()
+        """ support multi devices, use `,` to split """
+        serial_list = serial.split(',')
+        for each_serial in serial_list:
+            ins = Installer(each_serial)
+            ins.launch_and_check()
 
 
 def main():


### PR DESCRIPTION
- 在很多实际使用场景中，设备通常是固化的
- 这些设备在固化时都已经经过了`python -m uiautomator2 init`，在每次自动化测试时没必要都init
- atx-agent还蛮容易被杀掉的，经常需要重启
- 增加简单的重启agent的功能
