### PR TITLE
Provide alternative install location for /data/local/tmp

### DIFF
--- a/uiautomator2/__main__.py
+++ b/uiautomator2/__main__.py
@@ -99,7 +99,7 @@ class Installer(adbutils.Adb):
         self.server_addr = None
 
     def get_executable_dir(self):
-        dirs = ['/sdcard/', '/data/data/com.android.shell']
+        dirs = ['/data/local/tmp', '/data/data/com.android.shell']
         for dirname in dirs:
             testpath = os.path.join(dirname, 'permtest')
             self.shell('touch', testpath, raise_error=False)
@@ -181,11 +181,6 @@ class Installer(adbutils.Adb):
         if not pkg_test_info:
             raise EnvironmentError(
                 "package com.github.uiautomator.test not installed")
-
-    def install_atx_agent_dev(self):
-        exedir = self.get_executable_dir()
-        self.push("./lib/agent/atx-agent", exedir, 0o755)
-        log.debug("atx-agent installed")
 
     def install_atx_agent(self, agent_version, reinstall=False):
         version_output = self.shell(
@@ -312,8 +307,7 @@ class MyFire(object):
         ins.install_minicap()
         ins.install_minitouch()
         ins.install_uiautomator_apk(apk_version, reinstall)
-        ins.install_atx_agent_dev()
-        # ins.install_atx_agent(agent_version, reinstall)
+        ins.install_atx_agent(agent_version, reinstall)
         if not ignore_apk_check:
             ins.check_apk_installed(apk_version)
         ins.launch_and_check()

--- a/uiautomator2/__main__.py
+++ b/uiautomator2/__main__.py
@@ -101,7 +101,7 @@ class Installer(adbutils.Adb):
     def get_executable_dir(self):
         dirs = ['/data/local/tmp', '/data/data/com.android.shell']
         for dirname in dirs:
-            testpath = os.path.join(dirname, 'permtest')
+            testpath = "%s/%s" % (dirname, 'permtest')
             self.shell('touch', testpath, raise_error=False)
             self.shell('chmod', '+x', testpath, raise_error=False)
             content = self.shell('stat', '-c%A', testpath, raise_error=False)
@@ -123,7 +123,7 @@ class Installer(adbutils.Adb):
         url = base_url + self.abi + "/lib/android-" + sdk + "/minicap.so"
         path = cache_download(url)
         exedir = self.get_executable_dir()
-        minicapdst = os.path.join(exedir, 'minicap.so')
+        minicapdst = "%s/%s" % (exedir, 'minicap.so')
         self.push(path, minicapdst)
         log.info("install minicap")
         url = base_url + self.abi + "/bin/minicap"
@@ -227,7 +227,7 @@ class Installer(adbutils.Adb):
     def launch_and_check(self):
         log.info("launch atx-agent daemon")
         exedir = self.get_executable_dir()
-        exefile = os.path.join(exedir, 'atx-agent')
+        exefile = "%s/%s" % (exedir, 'atx-agent')
         args = ['TMPDIR=/sdcard', exefile, '-d']
         if self.server_addr:
             args.append('-t')

--- a/uiautomator2/__main__.py
+++ b/uiautomator2/__main__.py
@@ -96,6 +96,7 @@ class Installer(adbutils.Adb):
         self.abi = self.getprop('ro.product.cpu.abi')
         self.pre = self.getprop('ro.build.version.preview_sdk')
         self.arch = self.getprop('ro.arch')
+        self.brand = self.getprop('ro.product.brand')
         self.server_addr = None
 
     def install_minicap(self):
@@ -113,7 +114,10 @@ class Installer(adbutils.Adb):
         log.info("install minicap")
         url = base_url + self.abi + "/bin/minicap"
         path = cache_download(url)
-        self.push(path, '/data/local/tmp/minicap', 0o755)
+        if self.brand.upper() in ['ZUK']:
+            self.push(path, '/data/data/com.android.shell', 0o755)
+        else:
+            self.push(path, '/data/local/tmp/minicap', 0o755)
 
     def install_minitouch(self):
         """ Need test """
@@ -124,7 +128,10 @@ class Installer(adbutils.Adb):
             self.abi + "/bin/minitouch"
         ])
         path = cache_download(url)
-        self.push(path, '/data/local/tmp/minitouch', 0o755)
+        if self.brand.upper() in ['ZUK']:
+            self.push(path, '/data/data/com.android.shell', 0o755)
+        else:
+            self.push(path, '/data/local/tmp/minitouch', 0o755)
 
     def install_uiautomator_apk(self, apk_version, reinstall=False):
         app_url = 'https://github.com/openatx/android-uiautomator-server/releases/download/%s/app-uiautomator.apk' % apk_version
@@ -165,6 +172,13 @@ class Installer(adbutils.Adb):
         if not pkg_test_info:
             raise EnvironmentError(
                 "package com.github.uiautomator.test not installed")
+
+    def install_atx_agent_dev(self):
+        if self.brand.upper() in ['ZUK']:
+            self.push("./lib/agent/atx-agent", '/data/data/com.android.shell', 0o755)
+        else:
+            self.push("./lib/agent/atx-agent", '/data/local/tmp/atx-agent', 0o755)
+        log.debug("atx-agent installed")
 
     def install_atx_agent(self, agent_version, reinstall=False):
         version_output = self.shell(
@@ -210,7 +224,10 @@ class Installer(adbutils.Adb):
 
     def launch_and_check(self):
         log.info("launch atx-agent daemon")
-        args = ['TMPDIR=/sdcard', '/data/local/tmp/atx-agent', '-d']
+        if self.brand.upper() in ['ZUK']:
+            args = ['TMPDIR=/sdcard', '/data/data/com.android.shell/atx-agent', '-d']
+        else:
+            args = ['TMPDIR=/sdcard', '/data/local/tmp/atx-agent', '-d']
         if self.server_addr:
             args.append('-t')
             args.append(self.server_addr)
@@ -289,7 +306,8 @@ class MyFire(object):
         ins.install_minicap()
         ins.install_minitouch()
         ins.install_uiautomator_apk(apk_version, reinstall)
-        ins.install_atx_agent(agent_version, reinstall)
+        ins.install_atx_agent_dev()
+        # ins.install_atx_agent(agent_version, reinstall)
         if not ignore_apk_check:
             ins.check_apk_installed(apk_version)
         ins.launch_and_check()


### PR DESCRIPTION
Recently I encounted some Lenovo device, whose /data/local/tmp is readonly, the solution is to install to another directory, so add an get_executable_dir method to Installer class.