### PR TITLE
fix adb.shell() args error for use adbutils.py

### DIFF
--- a/uiautomator2/__init__.py
+++ b/uiautomator2/__init__.py
@@ -152,7 +152,7 @@ def connect_usb(serial=None):
         warnings.warn("backend atx-agent is not alive, start again ...",
                       RuntimeWarning)
         # TODO: /data/local/tmp might not be execuable and atx-agent can be somewhere else
-        adb.shell("/data/local/tmp/atx-agent", "server", "-d")
+        adb.shell(device.serial, ("/data/local/tmp/atx-agent", "server", "-d"))
         deadline = time.time() + 3
         while time.time() < deadline:
             if d.alive:


### PR DESCRIPTION
The func `shell()` in adbutils.py is diffrent with pure-python-adb.