### PR TITLE
python -m uiautomator2 init 初始化403报错hotfix

### DIFF
--- a/uiautomator2/__main__.py
+++ b/uiautomator2/__main__.py
@@ -57,7 +57,15 @@ def cache_download(url, filename=None):
     if os.path.exists(storepath) and os.path.getsize(storepath) > 0:
         return storepath
     # download from url
-    r = requests.get(url, stream=True)
+    headers = {
+        'Accept': '*/*',
+        'Accept-Encoding': 'gzip, deflate, br',
+        'Accept-Language': 'zh-CN,zh;q=0.8,zh-TW;q=0.7,zh-HK;q=0.5,en-US;q=0.3,en;q=0.2',
+        'Connection': 'keep-alive',
+        'Origin': 'https://github.com',
+        'User-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.86 Safari/537.36'
+    }
+    r = requests.get(url, stream=True, headers=headers)
     if r.status_code != 200:
         raise Exception(url, "status code", r.status_code)
     file_size = int(r.headers.get("Content-Length"))
@@ -117,7 +125,7 @@ class Initer():
         if not name:
             raise Exception(
                 "arch(%s) need to be supported yet, please report an issue in github"
-                % abis)
+                % self.abis)
         return GITHUB_BASEURL + '/atx-agent/releases/download/%s/%s' % (
             __atx_agent_version__, name.format(v=__atx_agent_version__))
 


### PR DESCRIPTION
1、`python -m uiautomator2 init` 初始化403报错，请求头增加header
```py
$ python -m uiautomator2 init
[D 190327 10:56:08 __main__:28] use cache directory: /Users/wanghao/.uiautomator2
Namespace(serial=None, server=None, subparser='init') init
[I 190327 10:56:08 __main__:82] >>> Initial device AdbDevice(serial=84c30b0)
[I 190327 10:56:08 __main__:168] Install minicap, minitouch
url: https://github.com/openatx/stf-binaries/raw/master/node_modules/minitouch-prebuilt/prebuilt/arm64-v8a/bin/minitouch
r: <Response [403]>
Traceback (most recent call last):
  File "/usr/local/Cellar/python/3.7.2_2/Frameworks/Python.framework/Versions/3.7/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/local/Cellar/python/3.7.2_2/Frameworks/Python.framework/Versions/3.7/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/usr/local/lib/python3.7/site-packages/uiautomator2/__main__.py", line 353, in <module>
    main()
  File "/usr/local/lib/python3.7/site-packages/uiautomator2/__main__.py", line 343, in main
    actions[args.subparser](args)
  File "/usr/local/lib/python3.7/site-packages/uiautomator2/__main__.py", line 294, in cmd_init
    init.install(args.server)
  File "/usr/local/lib/python3.7/site-packages/uiautomator2/__main__.py", line 169, in install
    self.push_url(self.minitouch_url)
  File "/usr/local/lib/python3.7/site-packages/uiautomator2/__main__.py", line 145, in push_url
    path = cache_download(url, os.path.basename(url))
  File "/usr/local/lib/python3.7/site-packages/uiautomator2/__main__.py", line 64, in cache_download
    raise Exception(url, "status code", r.status_code)
Exception: ('https://github.com/openatx/stf-binaries/raw/master/node_modules/minitouch-prebuilt/prebuilt/arm64-v8a/bin/minitouch', 'status code', 403)
```
2、atx_agent_url 中报错变量错误修复