### PR TITLE
fix debug mode decode error

### DIFF
--- a/uiautomator2/__init__.py
+++ b/uiautomator2/__init__.py
@@ -223,7 +223,7 @@ class TimeoutRequestsSession(requests.Session):
             print(
                 datetime.now().strftime("%H:%M:%S.%f")[:-3],
                 "$ curl -X {method} -d '{data}' '{url}'".format(
-                    method=method, url=url, data=data.decode()))
+                    method=method, url=url, data=data))
         try:
             resp = super(TimeoutRequestsSession, self).request(
                 method, url, **kwargs)


### PR DESCRIPTION
```py
----> 1 d.shell('pwd')

/usr/local/lib/python3.7/site-packages/uiautomator2/__init__.py in shell(self, cmdargs, stream, timeout)
    761                 'command': cmdargs,
    762                 'timeout': str(timeout)
--> 763             }, timeout=timeout+10)
    764         if ret.status_code != 200:
    765             raise RuntimeError(

/usr/local/lib/python3.7/site-packages/requests/sessions.py in post(self, url, data, json, **kwargs)
    579         """
    580
--> 581         return self.request('POST', url, data=data, json=json, **kwargs)
    582
    583     def put(self, url, data=None, **kwargs):

/usr/local/lib/python3.7/site-packages/uiautomator2/__init__.py in request(self, method, url, **kwargs)
    224                 datetime.now().strftime("%H:%M:%S.%f")[:-3],
    225                 "$ curl -X {method} -d '{data}' '{url}'".format(
--> 226                     method=method, url=url, data=data.decode()))
    227         try:
    228             resp = super(TimeoutRequestsSession, self).request(

AttributeError: 'str' object has no attribute 'decode'
```
in https://github.com/openatx/uiautomator2/blob/master/uiautomator2/__init__.py#L214
```py
            if isinstance(data, dict):
                data = json.dumps(data)
            ...
           data=data.decode()
```
json.dumps return a str obj, remove decode to fix it.     
