### PR TITLE
fix bug for send press key code

### DIFF
--- a/uiautomator2/__init__.py
+++ b/uiautomator2/__init__.py
@@ -1096,7 +1096,7 @@ class _Device(_BaseClient):
         with self._operation_delay("press"):
             if isinstance(key, int):
                 return self.jsonrpc.pressKeyCode(
-                    key, meta) if meta else self.server.jsonrpc.pressKeyCode(key)
+                    key, meta) if meta else self.jsonrpc.pressKeyCode(key)
             else:
                 return self.jsonrpc.pressKey(key)
 


### PR DESCRIPTION
fix bug for send press key code

throw below error when send keycode through d.press(keycode)
Traceback (most recent call last):
  File "<string>", line 6, in <module>
  File "E:\python3.7.4\lib\site-packages\uiautomator2\__init__.py", line 1090, in press
    key, meta) if meta else self.server.jsonrpc.pressKeyCode(key)
AttributeError: 'Device' object has no attribute 'server'