### PR TITLE
fix #655 （修复图像匹配功能）

### DIFF
--- a/uiautomator2/image.py
+++ b/uiautomator2/image.py
@@ -13,7 +13,7 @@ import typing
 from typing import Union
 
 import cv2
-# import findit
+import findit
 import imutils
 import numpy as np
 import requests


### PR DESCRIPTION
相关 issue #655 

图像匹配功能因该行注释损坏，取消注释。

如果该行注释不能取消，希望能告知不改包的图像匹配使用方法。