### PR TITLE
update adb client host

### DIFF
--- a/uiautomator2/__init__.py
+++ b/uiautomator2/__init__.py
@@ -281,7 +281,7 @@ class _BaseClient(object):
         try:
             lport = self._adb_device.forward_port(
                 7912)  # this method is so fast, only take 0.2ms
-            return f"http://127.0.0.1:{lport}"
+            return f"http://{self._adb_device._client.host}:{lport}"
         except adbutils.AdbError as e:
             if not _is_tmq_production() and self._atx_agent_url:
                 # when device offline, use atx-agent-url

--- a/uiautomator2/init.py
+++ b/uiautomator2/init.py
@@ -357,11 +357,12 @@ class Initer():
     def check_atx_agent_version(self):
         port = self._device.forward_port(7912)
         self.logger.debug("Forward: local:tcp:%d -> remote:tcp:%d", port, 7912)
-        version = requests.get("http://127.0.0.1:%d/version" %
-                               port).text.strip()
+        version = requests.get("http://%s:%d/version" %
+                               (self._device._client.host, port)).text.strip()
         self.logger.debug("atx-agent version %s", version)
 
-        wlan_ip = requests.get("http://127.0.0.1:%d/wlan/ip" % port).text.strip()
+        wlan_ip = requests.get("http://%s:%d/wlan/ip" %
+                               (self._device._client.host, port)).text.strip()
         self.logger.debug("device wlan ip: %s", wlan_ip)
         return version
 


### PR DESCRIPTION
adb client host不应该写成localhost，特别是docker多容器构建，一般会使用宿主机的IP作为host。