### PR TITLE
优化对本地模拟器的连接速度

### DIFF
--- a/uiautomator2/__init__.py
+++ b/uiautomator2/__init__.py
@@ -1889,6 +1889,9 @@ def _fix_wifi_addr(addr: str) -> Optional[str]:
         return None
     if re.match(r"^https?://", addr):  # eg: http://example.org
         return addr
+    # eg: emulator-5554, 127.0.0.1:5555
+    if addr.startswith('emulator-') or addr.startswith('127.0.0.1:'):
+        return None
 
     # make a request
     # eg: 10.0.0.1, 10.0.0.1:7912


### PR DESCRIPTION
本地模拟器使用 `127.0.0.1:5555`, `emulator-5554` 等作为 serial。调用 u2.connect() 时，`_fix_wifi_addr()` 会请求 `http://emulator-5554/version`，但需要等待 requests 超时才会抛出域名解析错误的异常，请求 `http://127.0.0.1:5555/version` 也需要等到读取超时

以 `emulator-` 开头或者是 `127.0.0.1:` 开头的都是本地模拟器了，直接绕过可以节省两秒钟

https://github.com/openatx/uiautomator2/blob/08d718677237324f3f6c7e4177f42c1398f79a3f/uiautomator2/__init__.py#L1887-L1902

