### PR TITLE
pin the version of adbutils to 1.0.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ whichcraft
 logzero~=1.5
 progress~=1.3
 retry~=0.9
-adbutils>=1.0.9
+adbutils==1.0.9
 Deprecated~=1.2.6
 
 # Not supported in QPython


### PR DESCRIPTION
README.md said that this project requires the version of python 3.6+, but when we automatically install the latest version of this project, the code of the dependent adbutil project (version number 1.2.1, [code location|https://github.com/openatx/adbutils/blob/master/adbutils/_device.py#L351]) requires that the version of python should actually be 3.7+ (re.Pattern class was introduced in python 3.7), which breaks the description in README.md.