### PR TITLE
Addresses issue #823 in owner repo.

### DIFF
--- a/uiautomator2/__init__.py
+++ b/uiautomator2/__init__.py
@@ -490,6 +490,7 @@ class _BaseClient(object):
                 NullPointerExceptionError,
                 StaleObjectExceptionError) as e:
             self.logger.warning("jsonrpc call got: %s", str(e))
+            self.reset_uiautomator(str(e))  # added to fix strange fatal jsonrpc NullPointerException
         return self._jsonrpc_call(*args, **kwargs)
 
     def _jsonrpc_call(self, method, params=[], http_timeout=60):


### PR DESCRIPTION
#823 was an error that it seems a few people were getting including myself!

Im not sure how to recreate it but it seems to happen after i unplug the device and plug it in again many hours later...
 there is the weird reported error, something like this:
 
 ```
[W 230209 14:48:54 __init__:497] [pid:48133] [11111JEC208976] jsonrpc call got: -32001 Jsonrpc error: <java.lang.NullPointerException> data: java.lang.NullPointerException: Attempt to read from field 'int android.accessibilityservice.AccessibilityServiceInfo.flags' on a null object reference in method 'void androidx.test.uiautomator.UiDevice.setCompressedLayoutHeirarchy(boolean)'
        at androidx.test.uiautomator.UiDevice.setCompressedLayoutHeirarchy(UiDevice.java:234)
        at com.github.uiautomator.stub.AutomatorServiceImpl.dumpWindowHierarchy(AutomatorServiceImpl.java:295)
        at com.github.uiautomator.stub.AutomatorServiceImpl.dumpWindowHierarchy(AutomatorServiceImpl.java:284)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.googlecode.jsonrpc4j.JsonRpcBasicServer.invoke(JsonRpcBasicServer.java:467)
        at com.googlecode.jsonrpc4j.JsonRpcBasicServer.handleObject(JsonRpcBasicServer.java:352)
        at com.googlecode.jsonrpc4j.JsonRpcBasicServer.handleJsonNodeRequest(JsonRpcBasicServer.java:283)
        at com.googlecode.jsonrpc4j.JsonRpcBasicServer.handleRequest(JsonRpcBasicServer.java:251)
        at com.github.uiautomator.stub.AutomatorHttpServer.serve(AutomatorHttpServer.java:100)
        at fi.iki.elonen.NanoHTTPD.serve(NanoHTTPD.java:2244)
        at fi.iki.elonen.NanoHTTPD$HTTPSession.execute(NanoHTTPD.java:945)
        at fi.iki.elonen.NanoHTTPD$ClientHandler.run(NanoHTTPD.java:192)
        at java.lang.Thread.run(Thread.java:1012)
    , method: dumpWindowHierarchy
```

And after this error the software drops out, instead this fix would catch that error and restart the server over again similar to if there is a ReadTimeout error.

I hope this is ok?