### PR TITLE
Requirements update

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ Deprecated~=1.2.6
 Pillow
 lxml>=4.3
 cached-property>=1.5.1,<2.0
-packaging~=20.3
+packaging>=20.3
 
 #websocket-client
 


### PR DESCRIPTION
Currently automated builds can be failed because of packaging~=20.3 version requirement. 
Looks fair to let uiautomator2 use newer versions.

