### PR TITLE
catch exception when _run_watchers

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,11 +1,11 @@
 [metadata]
 name = uiautomator2
 author = codeskyblue
-author-email = codeskyblue@gmail.com
+author_email = codeskyblue@gmail.com
 summary = Python Wrapper for Google Android UiAutomator2 test tool
 license = MIT
-description-file = ABOUT.rst
-home-page = https://github.com/openatx/uiautomator2
+description_file = ABOUT.rst
+home_page = https://github.com/openatx/uiautomator2
 # all classifier can be found in https://pypi.python.org/pypi?%3Aaction=list_classifiers
 classifier =
     Development Status :: 4 - Beta
@@ -32,5 +32,5 @@ image =
 
 [entry_points]
 # https://docs.openstack.org/pbr/3.1.1/#entry-points
-console_scripts = 
+console_scripts =
    uiautomator2 = uiautomator2.__main__:main

--- a/uiautomator2/watcher.py
+++ b/uiautomator2/watcher.py
@@ -53,7 +53,7 @@ class WatchContext:
         Args:
             seconds: stable seconds
             timeout: raise error when wait stable timeout
-            
+
         Raises:
             TimeoutError
         """
@@ -236,7 +236,11 @@ class Watcher():
         """
         if self.triggering:  # avoid to run watcher when run watcher
             return False
-        return self._run_watchers(source=source)
+        try:
+            return self._run_watchers(source=source)
+        except Exception as e:
+            self.logger.warning("_run_watchers exception: %s", e)
+            return False
 
     def _run_watchers(self, source=None) -> bool:
         """


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/Users/coco/.rye/py/cpython@3.8.16/install/lib/python3.8/threading.py", line 932, in _bootstrap_inner
    self.run()
  File "/Users/coco/.rye/py/cpython@3.8.16/install/lib/python3.8/threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
  File "/Users/coco/toy/.venv/lib/python3.8/site-packages/uiautomator2/watcher.py", line 227, in _watch_forever
    triggered = self.run()
  File "/Users/coco/toy/.venv/lib/python3.8/site-packages/uiautomator2/watcher.py", line 239, in run
    return self._run_watchers(source=source)
  File "/Users/coco/toy/.venv/lib/python3.8/site-packages/uiautomator2/watcher.py", line 246, in _run_watchers
    source = source or self._dump_hierarchy()
  File "/Users/coco/toy/.venv/lib/python3.8/site-packages/uiautomator2/watcher.py", line 175, in _dump_hierarchy
    return self._d.dump_hierarchy()
  File "/Users/coco/toy/.venv/lib/python3.8/site-packages/decorator.py", line 232, in fun
    return caller(func, *(extras + args), **kw)
  File "/Users/coco/toy/.venv/lib/python3.8/site-packages/retry/api.py", line 73, in retry_decorator
    return __retry_internal(partial(f, *args, **kwargs), exceptions, tries, delay, max_delay, backoff, jitter,
  File "/Users/coco/toy/.venv/lib/python3.8/site-packages/retry/api.py", line 33, in __retry_internal
    return f()
  File "/Users/coco/toy/.venv/lib/python3.8/site-packages/uiautomator2/__init__.py", line 978, in dump_hierarchy
    content = self.jsonrpc.dumpWindowHierarchy(compressed, None)
  File "/Users/coco/toy/.venv/lib/python3.8/site-packages/uiautomator2/__init__.py", line 479, in __call__
    return self.server._jsonrpc_retry_call(self.method, params,
  File "/Users/coco/toy/.venv/lib/python3.8/site-packages/uiautomator2/__init__.py", line 486, in _jsonrpc_retry_call
    return self._jsonrpc_call(*args, **kwargs)
  File "/Users/coco/toy/.venv/lib/python3.8/site-packages/uiautomator2/__init__.py", line 513, in _jsonrpc_call
    res = self.http.post("/jsonrpc/0",
  File "/Users/coco/toy/.venv/lib/python3.8/site-packages/requests/sessions.py", line 635, in post
    return self.request("POST", url, data=data, json=json, **kwargs)
  File "/Users/coco/toy/.venv/lib/python3.8/site-packages/uiautomator2/__init__.py", line 210, in request
    self.__client._is_agent_alive():
  File "/Users/coco/toy/.venv/lib/python3.8/site-packages/uiautomator2/__init__.py", line 586, in _is_agent_alive
    return bool(self._get_agent_version())
  File "/Users/coco/toy/.venv/lib/python3.8/site-packages/uiautomator2/__init__.py", line 570, in _get_agent_version
    url = self.path2url("/version")
  File "/Users/coco/toy/.venv/lib/python3.8/site-packages/uiautomator2/__init__.py", line 301, in path2url
    return urlparse.urljoin(self._get_atx_agent_url(), path)
  File "/Users/coco/toy/.venv/lib/python3.8/site-packages/uiautomator2/__init__.py", line 282, in _get_atx_agent_url
    lport = self._adb_device.forward_port(
  File "/Users/coco/toy/.venv/lib/python3.8/site-packages/adbutils/_device.py", line 249, in forward_port
    self.forward("tcp:" + str(local_port), remote)
  File "/Users/coco/toy/.venv/lib/python3.8/site-packages/adbutils/_device.py", line 239, in forward
    self.open_transport(":".join(args))
  File "/Users/coco/toy/.venv/lib/python3.8/site-packages/adbutils/_device.py", line 90, in open_transport
    c.check_okay()
  File "/Users/coco/toy/.venv/lib/python3.8/site-packages/adbutils/_adb.py", line 134, in check_okay
    raise AdbError(self.read_string_block())
adbutils.errors.AdbError
```

exception above cause watcher thread exit