### PR TITLE
Update packaging

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ Deprecated~=1.2.6
 Pillow
 lxml>=4.3
 cached-property>=1.5.1,<2.0
-packaging~=20.3
+packaging
 
 #websocket-client
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ Deprecated~=1.2.6
 Pillow
 lxml>=4.3
 cached-property>=1.5.1,<2.0
-packaging
+packaging>=20.3
 
 #websocket-client
 

--- a/uiautomator2/__init__.py
+++ b/uiautomator2/__init__.py
@@ -40,7 +40,7 @@ from typing import List, Optional, Tuple, Union
 import adbutils
 import filelock
 import logzero
-import packaging
+from packaging import version as packaging_version
 import requests
 import six
 import six.moves.urllib.parse as urlparse
@@ -719,7 +719,7 @@ class _BaseClient(object):
             return True
 
         # 检查版本是否过期
-        if apk_version < packaging.version.parse(__apk_version__):
+        if apk_version < packaging_version.parse(__apk_version__):
             return True
 
         # 检查测试apk是否存在
@@ -727,12 +727,12 @@ class _BaseClient(object):
             return True
         return False
 
-    def _package_version(self, package_name: str) -> Optional[packaging.version.Version]:
+    def _package_version(self, package_name: str) -> Optional[packaging_version.Version]:
         if self.shell(['pm', 'path', package_name]).exit_code != 0:
             return None
         dump_output = self.shell(['dumpsys', 'package', package_name]).output
         m = re.compile(r'versionName=(?P<name>[\d.]+)').search(dump_output)
-        return packaging.version.parse(m.group('name') if m else "")
+        return packaging_version.parse(m.group('name') if m else "")
 
     def _grant_app_permissions(self):
         self.logger.debug("grant permissions")


### PR DESCRIPTION
## 适配了更高版本的 packaging。
packaging 从 23.0 开始修改了 __init__.py 中的结构，导致的使用方法失效:
```python
# 最高 22.0 版本支持的使用方式
import packaging

packaging.version.parse 
```
这种方法在 >23.0 中失效， 修改了引入方式为（同时支持 20.3 版本）：
```python
from packaging import version as packaging_version
```
以适配更高版本的 packaging。同时修改了 requirements.txt 中的依赖。