### PR TITLE
feat:添加“自动授权应用权限”方法，指定包名后自动赋予被测应用运行时所需权限，不再出现运行时权限弹窗，避免对用例执行的干扰

### DIFF
--- a/mobile_tests/test_session.py
+++ b/mobile_tests/test_session.py
@@ -54,3 +54,7 @@ def test_session_app(dev: u2.Device, package_name):
 def test_session_window_size(dev: u2.Device):
     assert isinstance(dev.window_size(), tuple)
 
+
+def test_auto_grant_permissions(dev: u2.Device):
+    dev.app_auto_grant_permissions('com.tencent.mm')
+

--- a/uiautomator2/__init__.py
+++ b/uiautomator2/__init__.py
@@ -882,32 +882,33 @@ class _AppMixIn(AbstractShell):
             bool of operate
         """
         output, _ = self.shell(['dumpsys', 'package',  f'{package_name}'])
-        groupPattern = re.compile(r'^(\s*' + 'runtime' + r' permissions:[\s\S]+)', re.MULTILINE)
-        groupMatcher = groupPattern.search(output)
-        if not groupPattern:
+        group_pattern = re.compile(r'^(\s*' + 'runtime' + r' permissions:[\s\S]+)', re.MULTILINE)
+        group_matcher = group_pattern.search(output)
+        if not group_pattern:
             return False
-        groupMatch = groupMatcher.group(1)
-        lines = groupMatch.split("\n")
+        group_match = group_matcher.group(1)
+        lines = group_match.split("\n")
         if len(lines) < 2:
             return False
-        titleIndent = len(lines[0]) - len(lines[0].lstrip())
+        title_indent = len(lines[0]) - len(lines[0].lstrip())
         for i in range(1, len(lines)):
             line = lines[i]
-            currentIndent = len(line) - len(line.lstrip())
+            current_indent = len(line) - len(line.lstrip())
 
-            if currentIndent <= titleIndent:
+            if current_indent <= title_indent:
                 break
 
-            permissionNamePattern = re.compile(r'android\.\w*\.?permission\.\w+')
-            permissionNameMatcher = permissionNamePattern.search(line)
+            permission_name_pattern = re.compile(r'android\.\w*\.?permission\.\w+')
+            permission_name_matcher = permission_name_pattern.search(line)
 
-            if not permissionNameMatcher:
+            if not permission_name_matcher:
                 continue
             else:
-                permissionName = permissionNameMatcher.group()
-                print(permissionName)
-                self.shell(['pm', 'grant', f'{package_name}', permissionName])
+                permission_name = permission_name_matcher.group()
+                print(permission_name)
+                self.shell(['pm', 'grant', package_name, permission_name])
         return True
+
 
 class _DeprecatedMixIn:
     @property

--- a/uiautomator2/__init__.py
+++ b/uiautomator2/__init__.py
@@ -9,6 +9,7 @@ import dataclasses
 import logging
 import os
 import re
+import string
 import time
 import warnings
 from functools import cached_property
@@ -881,16 +882,9 @@ class _AppMixIn(AbstractShell):
         Returns:
             bool of operate
         """
+        device_api_version = self.shell(['getprop', 'ro.build.version.sdk']).output
+        device_api_version = device_api_version.rstrip("\n")
         output, _ = self.shell(['dumpsys', 'package',  f'{package_name}'])
-
-        app_target_api = None
-        target_api_pattern = re.compile(r"targetSdk=(?P<version>[^\s]+)")
-        target_api_matcher = target_api_pattern.search(output)
-        if target_api_matcher:
-            app_target_api = target_api_matcher.group("version")
-            print(f'find target api = {app_target_api}')
-        else:
-            print('find null target api version')
 
         group_pattern = re.compile(r'^(\s*' + 'runtime' + r' permissions:[\s\S]+)', re.MULTILINE)
         group_matcher = group_pattern.search(output)
@@ -901,7 +895,7 @@ class _AppMixIn(AbstractShell):
         if len(lines) < 2:
             return False
         title_indent = len(lines[0]) - len(lines[0].lstrip())
-        if app_target_api is None or int(app_target_api) < 23:
+        if device_api_version is None or int(device_api_version) < 23:
             print('Skipping permissions grant option,only target api greater or equal to 23 support')
             return True
         for i in range(1, len(lines)):


### PR DESCRIPTION
Android端6.0之后的系统，部分敏感权限系统强制要求运行时动态授权，会对用例执行产生干扰，需要自己处理。

参考Appium的启动参数autoGrantPermissions的实现原理，补齐相关能力。

[appium-adb中的实现方式](https://github.com/appium/appium-adb/blob/master/lib/helpers.js#L477)