### PR TITLE
Update safe_xmlstr filtering logic to include whitespace filtering

### DIFF
--- a/uiautomator2/xpath.py
+++ b/uiautomator2/xpath.py
@@ -34,6 +34,8 @@ class XPathError(Exception):
 
 
 def safe_xmlstr(s: str) -> str:
+    # https://www.w3.org/TR/xml/#NT-NameStartChar
+    s = s.strip()
     s = re.sub('[$@#&]', '.', s)
     s = re.sub('\\.+', '.', s)
     s = re.sub('^\\.|\\.$', '', s)


### PR DESCRIPTION
# Problem description

When the class of a node in the XML of `dump_hierarchy` is an empty space, running `d.xpath("xxx").match()` will raise an error `ValueError: Invalid tag name '  '`. 

# Reproduce the code

- [uidump.txt](https://github.com/user-attachments/files/19334159/uidump.txt)

```python
from uiautomator2.xpath import PageSource, XPathSelector

def main():
    with open("uidump.txt", "r") as f:
        content = f.read()
        source = PageSource(content)
        selector = XPathSelector("视频", None, source)
        try:
            selector.match()
        except ValueError as e:
            # e = ValueError("Invalid tag name '  '")
            print(f"{e = }")


if __name__ == "__main__":
    main()
```

# Related links

- https://www.w3.org/TR/xml/#NT-NameStartChar
- https://github.com/openatx/uiautomator2/blob/master/XPATH.md#special-notes
- https://github.com/openatx/uiautomator2/issues/670