### PR TITLE
Enable collecting u2.jar via importlib.resources

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,8 @@ lxml = "*"
 adbutils = "^2.9.1"
 Pillow = "*"
 retry2 = "^0.9.5"
+importlib-resources = { version = "6.4.5", markers = "python_version < '3.11'" }
+
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.1.1"


### PR DESCRIPTION
Hi @codeskyblue ,

May I propose to swap to use importlib.resources as the library which will collect u2.jar resource from the package and deploy it on the end device?
The change which I propose is connected with the build system(Buck2) which is creating executable binary. In current implementation, where we point to defined location, we are pointing to wrong location, as we are pointing to the location where executable binary is located, something like:

```
<path_to_binary>/<binary_file>/assets/u2.jar
```

The problem was solved by me by replacing the current implementation of pointing to file location via Path to logic implemented under importlib.resources.files.

I will be grateful, if you will look at my proposition, and consider to merge this small change, which is solving my problem, and potentially will solve problems for other users which use Buck2 build system

