### PR TITLE
Use display_id = 0 as default when no display id provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,6 @@ Empty
   - **[Stop all running apps](#stop-all-running-apps)**
   - **[Push and pull files](#push-and-pull-files)**
   - **[Other app operations](#other-app-operations)**
-  ```
 
 **[UI automation](#basic-api-usages)**
   - **[Shell commands](#shell-commands)**

--- a/README.md
+++ b/README.md
@@ -1267,10 +1267,6 @@ To specify a device, pass `--serial`, e.g., `python -m uiautomator2 --serial bff
     uiautomator2 start <package-name>
     uiautomator2 start <package-name>/<activity-name>
     ```
-- `list`: List connected devices
-    ```bash
-    uiautomator2 list
-    ```
 - `version`: Show uiautomator2 version
     ```bash
     uiautomator2 version

--- a/README.md
+++ b/README.md
@@ -105,7 +105,6 @@ Empty
   - **[Push and pull files](#push-and-pull-files)**
   - **[Other app operations](#other-app-operations)**
   ```
-  cheme)**
 
 **[UI automation](#basic-api-usages)**
   - **[Shell commands](#shell-commands)**

--- a/uiautomator2/__init__.py
+++ b/uiautomator2/__init__.py
@@ -80,7 +80,7 @@ class _Device(_BaseClient):
                 jpg_raw = base64.b64decode(base64_data)
                 pil_img = Image.open(io.BytesIO(jpg_raw))
             else:
-                pil_img = self._dev.screenshot(display_id=display_id)
+                pil_img = self._dev.screenshot(display_id=0)
         else:
             pil_img = self._dev.screenshot(display_id=display_id)
         


### PR DESCRIPTION
When multiple display in device, the screenshot will throw screencap error: cannot identify image file <_io.BytesIO object at 0x0000021DBBD09120> if no display id provided.

And in uiautodev, the screenshot will also failed because currently there not parameter for display_id in uiautodev.

So I think we can use 0 as defalut since physical display ID normally is 0.