### PR TITLE
Prevent crash by catching ConnectionError in _check_alive() after server stop with wifi-adb

### DIFF
--- a/uiautomator2/core.py
+++ b/uiautomator2/core.py
@@ -291,7 +291,7 @@ class BasicUiautomatorServer(AbstractUiautomatorServer):
         try:
             response = _http_request(self._dev, self._device_server_port, "GET", "/ping")
             return response.content == b"pong"
-        except (HTTPError, ConnectionError) as e:
+        except (HTTPError, ConnectionError):
             return False
     
     def stop_uiautomator(self, wait=True):


### PR DESCRIPTION
When using WiFi ADB connection, calling `stop_uiautomator()` may fail if the 
uiautomator service has already terminated. In this case, `_check_alive()` 
attempts an HTTP request to a non-existent server, resulting in:

    http.client.RemoteDisconnected: Remote end closed connection without response

This exception is not caught by the current `HTTPError` handler since 
`RemoteDisconnected` inherits from `ConnectionError`, not `HTTPError`.

Fix: Catch `ConnectionError`  in `_check_alive()`. When 
these exceptions occur, treat the service as stopped and return `False`.