### PR TITLE
feat: add rootinactive in dumpwindowhierarchy

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,6 +481,9 @@ Note: click, swipe, drag operations support percentage position values. Example:
     # pretty: format xml (default False)
     # max_depth: limit xml depth, default 50
     xml = d.dump_hierarchy(compressed=False, pretty=True, max_depth=30)
+
+    # root_in_active=True: dump only the active window root
+    xml = d.dump_hierarchy(root_in_active=True)
     ```
 
 * Open notification or quick settings

--- a/README_CN.md
+++ b/README_CN.md
@@ -476,6 +476,9 @@ Note: click, swipe, drag operations support percentage position values. Example:
     # pretty: format xml
     # max_depth: limit xml depth, default 50
     xml = d.dump_hierarchy(compressed=False, pretty=False, max_depth=50)
+
+    # root_in_active=True: only dump the active window root
+    xml = d.dump_hierarchy(root_in_active=True)
     ```
 
 * Open notification or quick settings

--- a/uiautomator2/__init__.py
+++ b/uiautomator2/__init__.py
@@ -101,7 +101,7 @@ class _Device(_BaseClient):
             return
         return image_convert(pil_img, format)
         
-    def dump_hierarchy(self, compressed=False, pretty=False, max_depth: Optional[int] = None) -> str:
+    def dump_hierarchy(self, compressed=False, pretty=False, max_depth: Optional[int] = None, root_in_active: Optional[bool] = None) -> str:
         """
         Dump window hierarchy
 
@@ -109,6 +109,7 @@ class _Device(_BaseClient):
             compressed (bool): return compressed xml
             pretty (bool): pretty print xml
             max_depth (int): max depth of hierarchy
+            root_in_active (bool): dump only the active window root when set
 
         Returns:
             xml content
@@ -116,11 +117,11 @@ class _Device(_BaseClient):
         try:
             if max_depth is None:
                 max_depth = self.settings['max_depth']
-            content = self._do_dump_hierarchy(compressed, max_depth)
+            content = self._do_dump_hierarchy(compressed, max_depth, root_in_active)
         except HierarchyEmptyError: # pragma: no cover
             logger.warning("dump empty, return empty xml")
             content = '<?xml version=\'1.0\' encoding=\'UTF-8\' standalone=\'yes\' ?>\r\n<hierarchy rotation="0" />'
-        
+
         if pretty:
             root = etree.fromstring(content.encode("utf-8"))
             content = etree.tostring(root, pretty_print=True, encoding='UTF-8', xml_declaration=True)
@@ -128,10 +129,13 @@ class _Device(_BaseClient):
         return content
 
     @retry(HierarchyEmptyError, tries=3, delay=1)
-    def _do_dump_hierarchy(self, compressed=False, max_depth=None) -> str:
+    def _do_dump_hierarchy(self, compressed=False, max_depth=None, root_in_active: Optional[bool] = None) -> str:
         if max_depth is None:
             max_depth = 50
-        content = self.jsonrpc.dumpWindowHierarchy(compressed, max_depth)
+        if root_in_active is None:
+            content = self.jsonrpc.dumpWindowHierarchy(compressed, max_depth)
+        else:
+            content = self.jsonrpc.dumpWindowHierarchy(compressed, max_depth, root_in_active)
         if content == "":
             raise HierarchyEmptyError("dump hierarchy is empty")
         

--- a/uiautomator2/abstract.py
+++ b/uiautomator2/abstract.py
@@ -6,7 +6,7 @@
 
 import abc
 import typing
-from typing import Any, List, NamedTuple, Tuple, Union
+from typing import Any, List, NamedTuple, Optional, Tuple, Union
 
 import adbutils
 from PIL import Image
@@ -77,7 +77,7 @@ class AbstractXPathBasedDevice(metaclass=abc.ABCMeta):
         """ return (width, height) """
     
     @abc.abstractmethod
-    def dump_hierarchy(self) -> str:
+    def dump_hierarchy(self, root_in_active: Optional[bool] = None) -> str:
         """ return xml content """
     
     @abc.abstractmethod

--- a/uiautomator2/assets/sync.sh
+++ b/uiautomator2/assets/sync.sh
@@ -5,7 +5,7 @@ set -e
 
 APK_VERSION=$(cat ../version.py| grep apk_version | awk '{print $NF}')
 APK_VERSION=${APK_VERSION//[\"\']}
-JAR_VERSION="0.3.1"
+JAR_VERSION="0.4.0"
 
 cd "$(dirname $0)"
 


### PR DESCRIPTION
## Summary

Add an opt-in `root_in_active` parameter to `dump_hierarchy()` so callers can request only the active window root from the uiautomator server.

The default behavior remains unchanged: when `root_in_active` is not provided, the client still sends the original two-argument `dumpWindowHierarchy(compressed, max_depth)` RPC call.

## Changes

- Add optional `root_in_active: Optional[bool] = None` parameter to `Device.dump_hierarchy()`.
- Keep backward compatibility by preserving the existing two-argument RPC call when `root_in_active` is not set.
- Send the new three-argument RPC call only when `root_in_active` is explicitly provided.
- Update the abstract device interface signature.
- Add README and README_CN examples for `dump_hierarchy(root_in_active=True)`.

## Compatibility

This change does not affect existing users:

- `d.dump_hierarchy()` keeps the original behavior.
- Existing servers that only support the two-argument RPC continue to work.
- The new three-argument RPC is used only when callers explicitly pass `root_in_active=True` or `root_in_active=False`.
